### PR TITLE
Make the rustix-futex-sync dependency optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies]
 rustix = { version = "0.38.8", default-features = false, features = ["mm"] }
-rustix-futex-sync = "0.2.1"
+rustix-futex-sync = { version = "0.2.1", optional = true }
 
 [dependencies]
 # For more information on these dependencies see rust-lang/rust's
@@ -37,7 +37,7 @@ debug-assertions = true
 [features]
 # Enable implementations of the `GlobalAlloc` standard library API, exporting a
 # new `GlobalDlmalloc` as well which implements this trait.
-global = []
+global = ["rustix-futex-sync"]
 
 # Enable very expensive debug checks in this crate
 debug = []


### PR DESCRIPTION
It's enabled by the "global" feature, but can be disabled otherwise.