### PR TITLE
docs: `Cargo.toml` - Update `rustc` dep upstream reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ rustix = { version = "1.0.0", default-features = false, features = ["mm"] }
 rustix-futex-sync = { version = "0.4.0", optional = true }
 
 [dependencies]
-# For more information on these dependencies see rust-lang/rust's
-# `src/tools/rustc-std-workspace` folder
+# For more information on these dependencies see:
+# https://github.com/rust-lang/rust/blob/main/library/rustc-std-workspace-core/README.md
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 compiler_builtins = { version = '0.1.0', optional = true }
 cfg-if = "1.0"


### PR DESCRIPTION
**UPDATE:** Looking at [`alexcrichton/dlmalloc-rs`](https://github.com/alexcrichton/dlmalloc-rs/commits/main/) vs [`sunfishcode/rustix-dlmalloc`](https://github.com/sunfishcode/rustix-dlmalloc/commits/main/) history, it seems you're maintaining the fork for rustix support by rewriting history with a rebase to sync for updates? I'll raise this PR upstream at `alexcrichton/dlmalloc-rs` instead then 👍 (_**EDIT:** [Done](https://github.com/alexcrichton/dlmalloc-rs/pull/63)_)

---

This appears to have [changed in 2020 with Rust 1.47](https://github.com/rust-lang/rust/pull/73265).

The reference doesn't quite communicate the context for usage here in this crate? I assume it's related to building the std lib with nightly? The comment might benefit from a little more context regarding that but I doubt most readers care (_if they don't grok the provided context_)? 😅 